### PR TITLE
feat/unityから受けとるメッセージのtypeをenumに切り出し，受け取るメッセージのtypeによる条件分岐にgame_startを追加

### DIFF
--- a/Streamario_web_backend/internal/handler/websocket.go
+++ b/Streamario_web_backend/internal/handler/websocket.go
@@ -46,11 +46,6 @@ const (
 	MessageTypeRoomReady WebSocketMessageType = "room_ready"
 )
 
-// String: WebSocketMessageTypeを文字列に変換
-func (t WebSocketMessageType) String() string {
-	return string(t)
-}
-
 type WebSocketHandler struct {
 	connections    map[string]*websocket.Conn
 	mu             sync.RWMutex
@@ -103,7 +98,7 @@ func (h *WebSocketHandler) HandleUnityConnection(c echo.Context) error {
 				initType = MessageTypeRoomReady
 			}
 			payload := map[string]interface{}{
-				"type":    initType.String(),
+				"type":    string(initType),
 				"room_id": id,
 			}
 			if err := h.SendEventToUnity(id, payload); err != nil {


### PR DESCRIPTION
# やったこと
- Unityとのやりとりに使うtypeをEnumに切り出した
```go
type WebSocketMessageType string

const (
	MessageTypeGameStart WebSocketMessageType = "game_start"
	MessageTypeGameEnd WebSocketMessageType = "game_end"
	MessageTypeRoomCreated WebSocketMessageType = "room_created"
	MessageTypeRoomReady WebSocketMessageType = "room_ready"
)
```

- Unityから受け取ったメッセージのtypeにgame_startを追加
```go
switch messageType {
case MessageTypeGameStart:
        if h.sessionService == nil {
                c.Logger().Warn("game_start received but sessionService not set")
                continue
        }
        c.Logger().Infof("game start received id=%s", id)
        c.Logger().Infof("game start を受け取りました\n 具体的な実装はまだです")
.
.
.
```
# やってないこと
- Unityからgame_startを受け取った後の具体的なロジックの実装
  - 本PRではログを出すだけ

# なんでやったか
#184 のテストするために，バックエンド側でgame_startを受け取れるようにする必要があった